### PR TITLE
Support Active Record 5.2.3

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ activerecord_versions =
   { "4.2" => (0..9).to_a,
     "5.0" => (0..6).to_a,
     "5.1" => (0..6).to_a,
-    "5.2" => [0],
+    "5.2" => (0..3).to_a,
   }.map do |base_version, tiny_versions|
     tiny_versions.map { |tiny_version| "#{base_version}.#{tiny_version}" }
   end.flatten

--- a/lib/active_record_association_query_economizer.rb
+++ b/lib/active_record_association_query_economizer.rb
@@ -5,7 +5,7 @@ activerecord_version = ActiveRecord.version
 case activerecord_version
 when Gem::Requirement.create(['>= 4.2', '< 5'])
   require 'active_record_association_query_economizer/rails4-2/associations'
-when Gem::Requirement.create(['>= 5.0', '<= 5.2.0'])
+when Gem::Requirement.create(['>= 5.0', '<= 5.2.3'])
   require 'active_record_association_query_economizer/rails5/associations'
 else
   Kernel.warn "active_record_association_query_economizer does nothing on ActiveRecord #{activerecord_version} because not supported."


### PR DESCRIPTION
Active Record 5.2.3に対応するためForkしてきました。


変更は、テスト時に利用していた以下のリポジトリの内容を反映しています。

https://github.com/skmtkytr/active_record_association_query_economizer/commits/master

